### PR TITLE
Add the ability to depend on another task

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -517,28 +517,8 @@ task.ci = [
 # --- needs tests ---
 
 
-def test_task_config_needs_list(tmp_path: Path) -> None:
-    """{needs = ["build"]} sets task.needs == ("build",)."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(
-        """
-[tool.werr]
-task.build = ["make"]
-task.test = [
-    {needs = ["build"]},
-    "pytest",
-]
-"""
-    )
-
-    tasks = config.load(pyproject)
-    test_task = next(t for t in tasks if t.name == "test")
-
-    assert test_task.needs == ("build",)
-
-
 def test_task_config_needs_string(tmp_path: Path) -> None:
-    """{needs = "build"} sets task.needs == ("build",)."""
+    """{needs = "build"} sets task.needs == "build"."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         """
@@ -554,11 +534,11 @@ task.test = [
     tasks = config.load(pyproject)
     test_task = next(t for t in tasks if t.name == "test")
 
-    assert test_task.needs == ("build",)
+    assert test_task.needs == "build"
 
 
 def test_task_without_needs(tmp_path: Path) -> None:
-    """Tasks without needs have empty tuple."""
+    """Tasks without needs have empty string."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         """
@@ -569,7 +549,7 @@ task.check = ["pytest"]
 
     tasks = config.load(pyproject)
 
-    assert tasks[0].needs == ()
+    assert tasks[0].needs == ""
 
 
 def test_needs_unknown_task_raises(tmp_path: Path) -> None:
@@ -646,6 +626,6 @@ task.test = [
 
     task, all_tasks = config.load_task(pyproject, cli_task="test")
 
-    assert task.needs == ("build",)
+    assert task.needs == "build"
     assert "build" in all_tasks
     assert "test" in all_tasks

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,7 +170,7 @@ task.check = ["ruff check .", "pytest"]
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert task.name == "check"
     assert isinstance(task.reporter, report.CliReporter)
@@ -183,7 +183,7 @@ def test_load_task_missing_werr_section(tmp_path: Path) -> None:
     pyproject.write_text('[project]\nname = "test"')
 
     with pytest.raises(ValueError, match=r"\[tool.werr\] section not found"):
-        config.load_task(pyproject)[0]
+        config.load_task(pyproject)
 
 
 def test_load_task_missing_task(tmp_path: Path) -> None:
@@ -206,7 +206,7 @@ def test_load_task_no_tasks(tmp_path: Path) -> None:
     pyproject.write_text("[tool.werr]")
 
     with pytest.raises(ValueError, match=r"does not contain any `task` lists"):
-        config.load_task(pyproject)[0]
+        config.load_task(pyproject)
 
 
 # --- Default task (first in dict) tests ---
@@ -223,7 +223,7 @@ task.test = ["pytest"]
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert task.name == "lint"
     assert task.commands == [Command(["ruff", "check", "."])]
@@ -240,7 +240,7 @@ task.build = ["make"]
 """
     )
 
-    task = config.load_task(pyproject, cli_task="build")[0]
+    task = config.load_task(pyproject, cli_task="build")
 
     assert task.name == "build"
     assert task.commands == [Command(["make"])]
@@ -262,7 +262,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is True
@@ -282,7 +282,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert isinstance(task.reporter, report.LiveReporter)
     assert task.commands == [Command(["pytest"])]
@@ -301,7 +301,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is True
@@ -318,7 +318,7 @@ task.check = ["pytest", "ruff check ."]
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is False
@@ -341,7 +341,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert [c.command for c in task.commands] == [
         ["uv", "run", "bash", "-c", "pytest | tee output.txt"]
@@ -358,7 +358,7 @@ task.check = ["ruff check ."]
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert task.commands == [Command(["ruff", "check", "."])]
 
@@ -379,7 +379,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject, cli_parallel=True)[0]
+    task = config.load_task(pyproject, cli_parallel=True)
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is True
@@ -395,7 +395,7 @@ task.check = ["pytest"]
 """
     )
 
-    task = config.load_task(pyproject, cli_reporter="xml")[0]
+    task = config.load_task(pyproject, cli_reporter="xml")
 
     assert isinstance(task.reporter, report.XmlReporter)
 
@@ -410,7 +410,7 @@ task.check = ["pytest"]
 """
     )
 
-    task = config.load_task(pyproject, cli_parallel=True, cli_reporter="xml")[0]
+    task = config.load_task(pyproject, cli_parallel=True, cli_reporter="xml")
 
     assert isinstance(task.reporter, report.XmlReporter)
     assert task.parallel is True
@@ -430,7 +430,7 @@ task.check = ["ruff check {src}"]
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert task.commands == [Command(["ruff", "check", "src/app"])]
 
@@ -447,7 +447,7 @@ task.check = ["ruff check {src} {tests}"]
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert task.commands == [Command(["ruff", "check", "src", "tests"])]
 
@@ -462,7 +462,7 @@ task.check = ["echo {unknown}"]
 """
     )
 
-    task = config.load_task(pyproject)[0]
+    task = config.load_task(pyproject)
 
     assert task.commands == [Command(["echo", "{unknown}"])]
 
@@ -483,7 +483,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject, cli_reporter="xml")[0]
+    task = config.load_task(pyproject, cli_reporter="xml")
 
     assert isinstance(task.reporter, report.XmlReporter)
     assert task.parallel is True
@@ -506,11 +506,11 @@ task.ci = [
 """
     )
 
-    task1 = config.load_task(pyproject)[0]
+    task1 = config.load_task(pyproject)
     assert isinstance(task1.reporter, report.CliReporter)
     assert task1.parallel is True
 
-    task2 = config.load_task(pyproject, cli_task="ci")[0]
+    task2 = config.load_task(pyproject, cli_task="ci")
     assert isinstance(task2.reporter, report.LiveReporter)
 
 
@@ -518,7 +518,7 @@ task.ci = [
 
 
 def test_task_config_needs_string(tmp_path: Path) -> None:
-    """{needs = "build"} sets task.needs == "build"."""
+    """{needs = "build"} resolves task.needs to the build Task."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         """
@@ -534,11 +534,12 @@ task.test = [
     tasks = config.load(pyproject)
     test_task = next(t for t in tasks if t.name == "test")
 
-    assert test_task.needs == "build"
+    assert test_task.needs is not None
+    assert test_task.needs.name == "build"
 
 
 def test_task_without_needs(tmp_path: Path) -> None:
-    """Tasks without needs have empty string."""
+    """Tasks without needs have None."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         """
@@ -549,7 +550,7 @@ task.check = ["pytest"]
 
     tasks = config.load(pyproject)
 
-    assert tasks[0].needs == ""
+    assert tasks[0].needs is None
 
 
 def test_needs_unknown_task_raises(tmp_path: Path) -> None:
@@ -624,8 +625,7 @@ task.test = [
 """
     )
 
-    task, all_tasks = config.load_task(pyproject, cli_task="test")
+    task = config.load_task(pyproject, cli_task="test")
 
-    assert task.needs == "build"
-    assert "build" in all_tasks
-    assert "test" in all_tasks
+    assert task.needs is not None
+    assert task.needs.name == "build"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,7 +170,7 @@ task.check = ["ruff check .", "pytest"]
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert task.name == "check"
     assert isinstance(task.reporter, report.CliReporter)
@@ -226,7 +226,7 @@ task.test = ["pytest"]
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert task.name == "lint"
     assert task.commands == [Command(["ruff", "check", "."], use_dashname=True)]
@@ -243,7 +243,7 @@ task.build = ["make"]
 """
     )
 
-    task = config.load_task(pyproject, cli_task="build")
+    _, task = config.load_task(pyproject, cli_task="build")
 
     assert task.name == "build"
     assert task.commands == [Command(["make"])]
@@ -265,7 +265,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is True
@@ -285,7 +285,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert isinstance(task.reporter, report.LiveReporter)
     assert task.commands == [Command(["pytest"])]
@@ -304,7 +304,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is True
@@ -321,7 +321,7 @@ task.check = ["pytest", "ruff check ."]
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is False
@@ -347,7 +347,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert [c.command for c in task.commands] == [
         ["uv", "run", "bash", "-c", "pytest | tee output.txt"]
@@ -364,7 +364,7 @@ task.check = ["ruff check ."]
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert task.commands == [Command(["ruff", "check", "."], use_dashname=True)]
 
@@ -385,7 +385,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject, cli_parallel=True)
+    _, task = config.load_task(pyproject, cli_parallel=True)
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is True
@@ -401,7 +401,7 @@ task.check = ["pytest"]
 """
     )
 
-    task = config.load_task(pyproject, cli_reporter="xml")
+    _, task = config.load_task(pyproject, cli_reporter="xml")
 
     assert isinstance(task.reporter, report.XmlReporter)
 
@@ -416,7 +416,7 @@ task.check = ["pytest"]
 """
     )
 
-    task = config.load_task(pyproject, cli_parallel=True, cli_reporter="xml")
+    _, task = config.load_task(pyproject, cli_parallel=True, cli_reporter="xml")
 
     assert isinstance(task.reporter, report.XmlReporter)
     assert task.parallel is True
@@ -436,7 +436,7 @@ task.check = ["ruff check {src}"]
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert task.commands == [Command(["ruff", "check", "src/app"], use_dashname=True)]
 
@@ -453,7 +453,7 @@ task.check = ["ruff check {src} {tests}"]
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert task.commands == [
         Command(["ruff", "check", "src", "tests"], use_dashname=True)
@@ -470,7 +470,7 @@ task.check = ["echo {unknown}"]
 """
     )
 
-    task = config.load_task(pyproject)
+    _, task = config.load_task(pyproject)
 
     assert task.commands == [Command(["echo", "{unknown}"])]
 
@@ -491,7 +491,7 @@ task.check = [
 """
     )
 
-    task = config.load_task(pyproject, cli_reporter="xml")
+    _, task = config.load_task(pyproject, cli_reporter="xml")
 
     assert isinstance(task.reporter, report.XmlReporter)
     assert task.parallel is True
@@ -514,11 +514,11 @@ task.ci = [
 """
     )
 
-    task1 = config.load_task(pyproject)
+    _, task1 = config.load_task(pyproject)
     assert isinstance(task1.reporter, report.CliReporter)
     assert task1.parallel is True
 
-    task2 = config.load_task(pyproject, cli_task="ci")
+    _, task2 = config.load_task(pyproject, cli_task="ci")
     assert isinstance(task2.reporter, report.LiveReporter)
 
 
@@ -633,7 +633,7 @@ task.test = [
 """
     )
 
-    task = config.load_task(pyproject, cli_task="test")
+    _, task = config.load_task(pyproject, cli_task="test")
 
     assert task.dependency is not None
     assert task.dependency.name == "build"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,7 +174,10 @@ task.check = ["ruff check .", "pytest"]
 
     assert task.name == "check"
     assert isinstance(task.reporter, report.CliReporter)
-    assert task.commands == [Command(["ruff", "check", "."]), Command(["pytest"])]
+    assert task.commands == [
+        Command(["ruff", "check", "."], use_dashname=True),
+        Command(["pytest"]),
+    ]
 
 
 def test_load_task_missing_werr_section(tmp_path: Path) -> None:
@@ -226,7 +229,7 @@ task.test = ["pytest"]
     task = config.load_task(pyproject)
 
     assert task.name == "lint"
-    assert task.commands == [Command(["ruff", "check", "."])]
+    assert task.commands == [Command(["ruff", "check", "."], use_dashname=True)]
 
 
 def test_cli_task_overrides_default(tmp_path: Path) -> None:
@@ -322,7 +325,10 @@ task.check = ["pytest", "ruff check ."]
 
     assert isinstance(task.reporter, report.CliReporter)
     assert task.parallel is False
-    assert task.commands == [Command(["pytest"]), Command(["ruff", "check", "."])]
+    assert task.commands == [
+        Command(["pytest"]),
+        Command(["ruff", "check", "."], use_dashname=True),
+    ]
 
 
 # --- shell config dict tests ---
@@ -360,7 +366,7 @@ task.check = ["ruff check ."]
 
     task = config.load_task(pyproject)
 
-    assert task.commands == [Command(["ruff", "check", "."])]
+    assert task.commands == [Command(["ruff", "check", "."], use_dashname=True)]
 
 
 # --- CLI overrides config dict tests ---
@@ -432,7 +438,7 @@ task.check = ["ruff check {src}"]
 
     task = config.load_task(pyproject)
 
-    assert task.commands == [Command(["ruff", "check", "src/app"])]
+    assert task.commands == [Command(["ruff", "check", "src/app"], use_dashname=True)]
 
 
 def test_multiple_variables(tmp_path: Path) -> None:
@@ -449,7 +455,9 @@ task.check = ["ruff check {src} {tests}"]
 
     task = config.load_task(pyproject)
 
-    assert task.commands == [Command(["ruff", "check", "src", "tests"])]
+    assert task.commands == [
+        Command(["ruff", "check", "src", "tests"], use_dashname=True)
+    ]
 
 
 def test_unknown_variable_preserved(tmp_path: Path) -> None:
@@ -518,7 +526,7 @@ task.ci = [
 
 
 def test_task_config_needs_string(tmp_path: Path) -> None:
-    """{needs = "build"} resolves task.needs to the build Task."""
+    """{needs = "build"} resolves task.dependency to the build Task."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -534,8 +534,8 @@ task.test = [
     tasks = config.load(pyproject)
     test_task = next(t for t in tasks if t.name == "test")
 
-    assert test_task.needs is not None
-    assert test_task.needs.name == "build"
+    assert test_task.dependency is not None
+    assert test_task.dependency.name == "build"
 
 
 def test_task_without_needs(tmp_path: Path) -> None:
@@ -550,7 +550,7 @@ task.check = ["pytest"]
 
     tasks = config.load(pyproject)
 
-    assert tasks[0].needs is None
+    assert tasks[0].dependency is None
 
 
 def test_needs_unknown_task_raises(tmp_path: Path) -> None:
@@ -627,5 +627,5 @@ task.test = [
 
     task = config.load_task(pyproject, cli_task="test")
 
-    assert task.needs is not None
-    assert task.needs.name == "build"
+    assert task.dependency is not None
+    assert task.dependency.name == "build"

--- a/tests/test_needs.py
+++ b/tests/test_needs.py
@@ -53,8 +53,12 @@ def test_deps_run_before_leaf(tmp_path: Path, mock_run: MagicMock) -> None:
     reporters: list[report.Reporter] = []
 
     def _side_effect(
-        _proj: Path, reporter: report.Reporter, cmds: list[Command],
-        _nf: str | None, *, _parallel: bool = False,
+        _proj: Path,
+        reporter: report.Reporter,
+        cmds: list[Command],
+        _nf: str | None,
+        *,
+        parallel: bool = False,  # noqa: ARG001
     ) -> bool:
         order.append(cmds[0].name)
         reporters.append(reporter)
@@ -77,8 +81,12 @@ def test_dep_failure_skips_leaf(tmp_path: Path, mock_run: MagicMock) -> None:
     names: list[str] = []
 
     def _side_effect(
-        _proj: Path, _reporter: report.Reporter, cmds: list[Command],
-        _nf: str | None, *, _parallel: bool = False,
+        _proj: Path,
+        _reporter: report.Reporter,
+        cmds: list[Command],
+        _nf: str | None,
+        *,
+        parallel: bool = False,  # noqa: ARG001
     ) -> bool:
         names.append(cmds[0].name)
         return False  # build fails
@@ -99,8 +107,12 @@ def test_transitive_deps(tmp_path: Path, mock_run: MagicMock) -> None:
     order: list[str] = []
 
     def _side_effect(
-        _proj: Path, _reporter: report.Reporter, cmds: list[Command],
-        _nf: str | None, *, _parallel: bool = False,
+        _proj: Path,
+        _reporter: report.Reporter,
+        cmds: list[Command],
+        _nf: str | None,
+        *,
+        parallel: bool = False,  # noqa: ARG001
     ) -> bool:
         order.append(cmds[0].name)
         return True
@@ -173,8 +185,12 @@ def test_name_filter_applies_to_all(tmp_path: Path, mock_run: MagicMock) -> None
     calls: list[tuple[str, str | None]] = []
 
     def _side_effect(
-        _proj: Path, _reporter: report.Reporter, cmds: list[Command],
-        nf: str | None, *, _parallel: bool = False,
+        _proj: Path,
+        _reporter: report.Reporter,
+        cmds: list[Command],
+        nf: str | None,
+        *,
+        parallel: bool = False,  # noqa: ARG001
     ) -> bool:
         calls.append((cmds[0].name, nf))
         return True

--- a/tests/test_needs.py
+++ b/tests/test_needs.py
@@ -1,0 +1,203 @@
+"""Test task dependency (needs) execution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, call, patch
+
+from werrlib import cli, config, report
+from werrlib.cmd import Command
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_task(
+    name: str,
+    *,
+    needs: tuple[str, ...] = (),
+    parallel: bool = False,
+    reporter: report.Reporter | None = None,
+    commands: list[Command] | None = None,
+) -> config.Task:
+    """Create a Task for testing."""
+    return config.Task(
+        name=name,
+        reporter=reporter or report.CliReporter(),
+        commands=commands if commands is not None else [Command([name])],
+        parallel=parallel,
+        project_name="test",
+        needs=needs,
+    )
+
+
+# --- Dependency ordering ---
+
+
+def test_deps_run_before_leaf(tmp_path: Path) -> None:
+    """Dependencies run before the leaf task."""
+    build = _make_task("build")
+    test = _make_task("test", needs=("build",))
+    all_tasks = {"build": build, "test": test}
+
+    order: list[str] = []
+
+    def mock_run(_proj, _reporter, cmds, _nf, *, parallel=False):  # noqa: ARG001
+        order.append(cmds[0].name)
+        return True
+
+    with patch("werrlib.cli.task.run", side_effect=mock_run):
+        result = cli._run_with_needs(tmp_path, test, all_tasks, None)
+
+    assert result is True
+    assert order == ["build", "test"]
+
+
+def test_dep_failure_skips_leaf(tmp_path: Path) -> None:
+    """When a dependency fails, the leaf task is not run."""
+    build = _make_task("build")
+    test = _make_task("test", needs=("build",))
+    all_tasks = {"build": build, "test": test}
+
+    call_count = 0
+
+    def mock_run(_proj, _reporter, cmds, _nf, *, parallel=False):  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        return False  # build fails
+
+    with patch("werrlib.cli.task.run", side_effect=mock_run):
+        result = cli._run_with_needs(tmp_path, test, all_tasks, None)
+
+    assert result is False
+    assert call_count == 1  # only build was attempted
+
+
+def test_diamond_deps_run_once(tmp_path: Path) -> None:
+    """Diamond dependency: shared dep runs exactly once."""
+    #   check
+    #   /   \
+    # build  lint
+    #   \   /
+    #   compile
+    compile_t = _make_task("compile")
+    build = _make_task("build", needs=("compile",))
+    lint = _make_task("lint", needs=("compile",))
+    check = _make_task("check", needs=("build", "lint"))
+    all_tasks = {
+        "compile": compile_t,
+        "build": build,
+        "lint": lint,
+        "check": check,
+    }
+
+    order: list[str] = []
+
+    def mock_run(_proj, _reporter, cmds, _nf, *, parallel=False):  # noqa: ARG001
+        order.append(cmds[0].name)
+        return True
+
+    with patch("werrlib.cli.task.run", side_effect=mock_run):
+        result = cli._run_with_needs(tmp_path, check, all_tasks, None)
+
+    assert result is True
+    assert order.count("compile") == 1
+    assert "check" in order
+    assert order[-1] == "check"
+
+
+def test_aggregation_task(tmp_path: Path) -> None:
+    """Task with needs but no commands succeeds after deps pass."""
+    build = _make_task("build")
+    lint = _make_task("lint")
+    check = _make_task("check", needs=("build", "lint"), commands=[])
+    all_tasks = {"build": build, "lint": lint, "check": check}
+
+    def mock_run(_proj, _reporter, cmds, _nf, *, parallel=False):  # noqa: ARG001
+        return True
+
+    with patch("werrlib.cli.task.run", side_effect=mock_run):
+        result = cli._run_with_needs(tmp_path, check, all_tasks, None)
+
+    assert result is True
+
+
+def test_cli_reporter_override_applies_to_all(tmp_path: Path) -> None:
+    """CLI reporter override applies to all tasks in the chain."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "testproject"
+
+[tool.werr]
+task.build = ["make"]
+task.test = [
+    {needs = "build"},
+    "pytest",
+]
+"""
+    )
+
+    task, all_tasks = config.load_task(pyproject, cli_task="test", cli_reporter="json")
+
+    assert isinstance(task.reporter, report.JsonReporter)
+    assert isinstance(all_tasks["build"].reporter, report.JsonReporter)
+
+
+def test_cli_parallel_override_applies_to_leaf_only(tmp_path: Path) -> None:
+    """CLI parallel override applies only to the leaf task."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "testproject"
+
+[tool.werr]
+task.build = ["make"]
+task.test = [
+    {needs = "build"},
+    "pytest",
+]
+"""
+    )
+
+    task, all_tasks = config.load_task(pyproject, cli_task="test", cli_parallel=True)
+
+    assert task.parallel is True
+    assert all_tasks["build"].parallel is False
+
+
+def test_name_filter_only_applies_to_leaf(tmp_path: Path) -> None:
+    """name_filter is only passed to the leaf task, not deps."""
+    build = _make_task("build", commands=[Command(["make"]), Command(["make", "install"])])
+    test = _make_task("test")
+    test_with_needs = _make_task("test", needs=("build",))
+    all_tasks = {"build": build, "test": test_with_needs}
+
+    calls: list[tuple[str, str | None]] = []
+
+    def mock_run(_proj, _reporter, cmds, nf, *, parallel=False):  # noqa: ARG001
+        calls.append((cmds[0].name, nf))
+        return True
+
+    with patch("werrlib.cli.task.run", side_effect=mock_run):
+        cli._run_with_needs(tmp_path, test_with_needs, all_tasks, "test")
+
+    # build should get nf=None, test should get nf="test"
+    assert calls[0] == ("make", None)
+    assert calls[1] == ("test", "test")
+
+
+def test_no_deps_works(tmp_path: Path) -> None:
+    """Tasks with no needs still work through _run_with_needs."""
+    check = _make_task("check")
+    all_tasks = {"check": check}
+
+    def mock_run(_proj, _reporter, cmds, _nf, *, parallel=False):  # noqa: ARG001
+        return True
+
+    with patch("werrlib.cli.task.run", side_effect=mock_run):
+        result = cli._run_with_needs(tmp_path, check, all_tasks, None)
+
+    assert result is True

--- a/tests/test_needs.py
+++ b/tests/test_needs.py
@@ -27,7 +27,7 @@ def _make_task(
         commands=commands if commands is not None else [Command([name])],
         parallel=parallel,
         project_name="test",
-        needs=needs,
+        dependency=needs,
     )
 
 
@@ -110,8 +110,8 @@ task.test = [
     t = config.load_task(pyproject, cli_task="test", cli_reporter="json")
 
     assert isinstance(t.reporter, report.JsonReporter)
-    assert t.needs is not None
-    assert isinstance(t.needs.reporter, report.JsonReporter)
+    assert t.dependency is not None
+    assert isinstance(t.dependency.reporter, report.JsonReporter)
 
 
 def test_cli_parallel_override_applies_to_leaf_only(tmp_path: Path) -> None:
@@ -134,8 +134,8 @@ task.test = [
     t = config.load_task(pyproject, cli_task="test", cli_parallel=True)
 
     assert t.parallel is True
-    assert t.needs is not None
-    assert t.needs.parallel is False
+    assert t.dependency is not None
+    assert t.dependency.parallel is False
 
 
 def test_name_filter_applies_to_all(tmp_path: Path) -> None:

--- a/tests/test_needs.py
+++ b/tests/test_needs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 from werrlib import cli, config, report
 from werrlib.cmd import Command
@@ -170,7 +170,9 @@ task.test = [
 
 def test_name_filter_only_applies_to_leaf(tmp_path: Path) -> None:
     """name_filter is only passed to the leaf task, not deps."""
-    build = _make_task("build", commands=[Command(["make"]), Command(["make", "install"])])
+    build = _make_task(
+        "build", commands=[Command(["make"]), Command(["make", "install"])]
+    )
     test = _make_task("test")
     test_with_needs = _make_task("test", needs=("build",))
     all_tasks = {"build": build, "test": test_with_needs}

--- a/tests/test_needs.py
+++ b/tests/test_needs.py
@@ -26,7 +26,6 @@ def _make_task(
         reporter=reporter or report.CliReporter(),
         commands=commands if commands is not None else [Command([name])],
         parallel=parallel,
-        project_name="test",
         dependency=needs,
     )
 
@@ -110,7 +109,7 @@ task.test = [
 """
     )
 
-    t = config.load_task(pyproject, cli_task="test", cli_reporter="json")
+    _, t = config.load_task(pyproject, cli_task="test", cli_reporter="json")
 
     # run_tree uses target.reporter for all deps, so only the target matters
     assert isinstance(t.reporter, report.JsonReporter)
@@ -137,7 +136,7 @@ task.test = [
 """
     )
 
-    t = config.load_task(pyproject, cli_task="test", cli_parallel=True)
+    _, t = config.load_task(pyproject, cli_task="test", cli_parallel=True)
 
     assert t.parallel is True
     assert t.dependency is not None

--- a/werrlib/cli.py
+++ b/werrlib/cli.py
@@ -178,9 +178,7 @@ def _run_with_needs(
             parallel = False
 
         nf = name_filter if is_leaf else None
-        success = task.run(
-            project, t.reporter, t.commands, nf, parallel=parallel
-        )
+        success = task.run(project, t.reporter, t.commands, nf, parallel=parallel)
 
         if success:
             completed.add(t.name)

--- a/werrlib/cli.py
+++ b/werrlib/cli.py
@@ -170,14 +170,14 @@ def run(argv: list[str]) -> None:
             )
         return
 
-    t = config.load_task(
+    project_name, t = config.load_task(
         args.project / "pyproject.toml",
         cli_task=args.task,
         cli_reporter=args.reporter,
         cli_parallel=args.cli_parallel,
     )
     t.reporter.emit_info(
-        f"Project: {t.project_name} ({"->".join(t.name for t in t.from_start())})"
+        f"Project: {project_name} ({"->".join(t.name for t in t.from_start())})"
     )
     success = task.run_tree(args.project, t, args.name)
 

--- a/werrlib/cli.py
+++ b/werrlib/cli.py
@@ -166,7 +166,7 @@ def run(argv: list[str]) -> None:
                 parallel=t.parallel,
                 reporter_name=t.reporter.name,
                 cmds=t.commands,
-                needs=t.needs.name if t.needs else "",
+                needs=t.dependency.name if t.dependency else "",
             )
         return
 

--- a/werrlib/cli.py
+++ b/werrlib/cli.py
@@ -166,18 +166,20 @@ def run(argv: list[str]) -> None:
                 parallel=t.parallel,
                 reporter_name=t.reporter.name,
                 cmds=t.commands,
-                needs=t.needs,
+                needs=t.needs.name if t.needs else "",
             )
         return
 
-    t, all_tasks = config.load_task(
+    t = config.load_task(
         args.project / "pyproject.toml",
         cli_task=args.task,
         cli_reporter=args.reporter,
         cli_parallel=args.cli_parallel,
     )
-    t.reporter.emit_info(f"Project: {t.project_name} ({t.name})")
-    success = task.run_tree(args.project, t, all_tasks, args.name)
+    t.reporter.emit_info(
+        f"Project: {t.project_name} ({"->".join(t.name for t in t.from_start())})"
+    )
+    success = task.run_tree(args.project, t, args.name)
 
     if not success:
         sys.exit(1)

--- a/werrlib/config.py
+++ b/werrlib/config.py
@@ -135,7 +135,11 @@ def _get_tasks(
             _command_from_template(c, variables, shell=opts.shell) for c in commands
         ]
         yield Task(
-            name, reporter, _deduplicate_names(cmds), parallel=opts.parallel, needs=needs
+            name,
+            reporter,
+            _deduplicate_names(cmds),
+            parallel=opts.parallel,
+            needs=needs,
         )
 
 
@@ -145,9 +149,7 @@ def _validate_needs(tasks: list[Task]) -> None:
     for t in tasks:
         for dep in t.needs:
             if dep not in names:
-                raise ValueError(
-                    f"task `{t.name}` needs unknown task `{dep}`"
-                )
+                raise ValueError(f"task `{t.name}` needs unknown task `{dep}`")
 
     # Cycle detection via DFS
     adj = {t.name: t.needs for t in tasks}

--- a/werrlib/report.py
+++ b/werrlib/report.py
@@ -40,7 +40,7 @@ class Reporter:
         parallel: bool,
         reporter_name: ReporterName,
         cmds: list[cmd.Command],
-        needs: tuple[str, ...] = (),
+        needs: str = "",
     ) -> None:
         """List a task."""
 
@@ -95,7 +95,7 @@ class CliReporter(Reporter):
         parallel: bool,
         reporter_name: ReporterName,
         cmds: list[cmd.Command],
-        needs: tuple[str, ...] = (),
+        needs: str = "",
     ) -> None:
         """List a task."""
         if parallel:
@@ -106,7 +106,7 @@ class CliReporter(Reporter):
             suffix = ""
 
         if needs:
-            suffix += f" -> {C.GREEN}{', '.join(needs)}{C.RESET}"
+            suffix += f" -> {C.GREEN}{needs}{C.RESET}"
 
         print(
             f"{C.BOLD_GREEN}{name}{C.RESET}{C.CYAN}{suffix}{C.RESET}\n"
@@ -170,7 +170,7 @@ class JsonReporter(Reporter):
         parallel: bool,
         reporter_name: ReporterName,
         cmds: list[cmd.Command],
-        needs: tuple[str, ...] = (),
+        needs: str = "",
     ) -> None:
         """List a task."""
         for c in cmds:
@@ -181,7 +181,7 @@ class JsonReporter(Reporter):
                         "reporter": reporter_name,
                         "parallel": parallel,
                         "command": shlex.join(c.command),
-                        "needs": list(needs),
+                        "needs": needs,
                     }
                 )
             )

--- a/werrlib/report.py
+++ b/werrlib/report.py
@@ -40,6 +40,7 @@ class Reporter:
         parallel: bool,
         reporter_name: ReporterName,
         cmds: list[cmd.Command],
+        needs: tuple[str, ...] = (),
     ) -> None:
         """List a task."""
 
@@ -94,6 +95,7 @@ class CliReporter(Reporter):
         parallel: bool,
         reporter_name: ReporterName,
         cmds: list[cmd.Command],
+        needs: tuple[str, ...] = (),
     ) -> None:
         """List a task."""
         if parallel:
@@ -102,6 +104,9 @@ class CliReporter(Reporter):
             suffix = " (live)"
         else:
             suffix = ""
+
+        if needs:
+            suffix += f" -> {', '.join(needs)}"
 
         print(
             f"{C.BOLD_GREEN}{name}{C.RESET}{C.CYAN}{suffix}{C.RESET}\n"
@@ -165,6 +170,7 @@ class JsonReporter(Reporter):
         parallel: bool,
         reporter_name: ReporterName,
         cmds: list[cmd.Command],
+        needs: tuple[str, ...] = (),
     ) -> None:
         """List a task."""
         for c in cmds:
@@ -175,6 +181,7 @@ class JsonReporter(Reporter):
                         "reporter": reporter_name,
                         "parallel": parallel,
                         "command": shlex.join(c.command),
+                        "needs": list(needs),
                     }
                 )
             )

--- a/werrlib/report.py
+++ b/werrlib/report.py
@@ -106,7 +106,7 @@ class CliReporter(Reporter):
             suffix = ""
 
         if needs:
-            suffix += f" -> {', '.join(needs)}"
+            suffix += f" -> {C.GREEN}{', '.join(needs)}{C.RESET}"
 
         print(
             f"{C.BOLD_GREEN}{name}{C.RESET}{C.CYAN}{suffix}{C.RESET}\n"

--- a/werrlib/task.py
+++ b/werrlib/task.py
@@ -96,11 +96,10 @@ def run_tree(
         if t.name in failed:
             return False
 
-        # Run dependencies first
-        for dep_name in t.needs:
-            if not _run_task(all_tasks[dep_name]):
-                failed.add(t.name)
-                return False
+        # Run dependency first
+        if t.needs and not _run_task(all_tasks[t.needs]):
+            failed.add(t.name)
+            return False
 
         success = run(project, t.reporter, t.commands, name_filter, parallel=t.parallel)
 


### PR DESCRIPTION
Add `needs` a task option which lets your task depend on another task.
(Execute the `needs` and run after).